### PR TITLE
added hour labels to support am/pm format if needed

### DIFF
--- a/src/jqCron.js
+++ b/src/jqCron.js
@@ -14,6 +14,7 @@ var jqCronDefaultSettings = {
 	texts: {},
 	monthdays: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31],
 	hours: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+	hour_labels: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23"],
 	minutes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59],
 	lang: 'en',
 	enabled_minute: false,
@@ -439,8 +440,8 @@ var jqCronDefaultSettings = {
 			// TIME  (hour:min)
 			_$blockTIME.append(_self.getText('text_time'));
 			_selectorTimeH = newSelector(_$blockTIME, settings.multiple_time_hours, 'time_hours');
-			for(i=0, list=settings.hours; i<list.length; i++){
-				_selectorTimeH.add(list[i], list[i]);
+			for(i=0, list=settings.hours, labelsList=settings.hour_labels; i<list.length; i++){
+				_selectorTimeH.add(list[i], labelsList[i]);
 			}
 			_selectorTimeM = newSelector(_$blockTIME, settings.multiple_time_minutes, 'time_minutes');
 			for(i=0, list=settings.minutes; i<list.length; i++){


### PR DESCRIPTION
Hello.
I need to support hours in 12h format with "AM" and "PM". Current implementation allows only 24h format. 12h  format could be introduced by using text labels for hours as it has been done for weekdays and months. "hour_labels" array is added to jqcron settings. Defaults are left as they were.
As a result, we can set hour labels to be "12PM, 1AM, 2AM... 10PM, 11PM".