### PR TITLE
Add korean translation, change pickers order

### DIFF
--- a/src/jqCron.js
+++ b/src/jqCron.js
@@ -321,15 +321,15 @@ var jqCronDefaultSettings = {
 
 		// get the human readable text
 		this.getHumanText = function() {
-		    var texts=[];
-		    _$obj
-		    .find('> span > span:visible')
-		    .find('.jqCron-text, .jqCron-selector > span')
-		    .each(function() {
-		        var text = $(this).text().replace(/\s+$/g, '').replace(/^\s+/g, '');
-		        text && texts.push(text);
-		    });
-		    return texts.join(' ').replace(/\s:\s/g, ':');
+				var texts=[];
+				_$obj
+				.find('> span > span:visible')
+				.find('.jqCron-text, .jqCron-selector > span')
+				.each(function() {
+						var text = $(this).text().replace(/\s+$/g, '').replace(/^\s+/g, '');
+						text && texts.push(text);
+				});
+				return texts.join(' ').replace(/\s:\s/g, ':');
 		}
 
 		// get settings
@@ -375,8 +375,16 @@ var jqCronDefaultSettings = {
 			settings.no_reset_button || _$obj.append(_$cross);
 			(!settings.disable) || _$obj.addClass('disable');
 			_$blocks.append(_$blockPERIOD);
-			_$blocks.append(_$blockDOM);
-			_$blocks.append(_$blockMONTH);
+
+			if ( /^(ko)$/i.test(settings.lang) )
+			{
+				_$blocks.append(_$blockMONTH, _$blockDOM);
+			}
+			else
+			{
+				_$blocks.append(_$blockDOM, _$blockMONTH);
+			}
+
 			_$blocks.append(_$blockMINS);
 			_$blocks.append(_$blockDOW);
 			_$blocks.append(_$blockTIME);

--- a/src/jqCron.ko.js
+++ b/src/jqCron.ko.js
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the Arnapou jqCron package.
+ *
+ * (c) Arnaud Buathier <arnaud@arnapou.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+jqCronDefaultSettings.texts.ko = {
+	empty: '매',
+	empty_minutes: '매',
+	empty_time_hours: '매',
+	empty_time_minutes: '매',
+	empty_day_of_week: '모든',
+	empty_day_of_month: '매',
+	empty_month: '매',
+	name_minute: '분',
+	name_hour: '시',
+	name_day: '일',
+	name_week: '주',
+	name_month: '월',
+	name_year: '년',
+	text_period: '매 <b />',
+	text_mins: ' <b />분',
+	text_time: ' <b />시 <b />분',
+	text_dow: ' <b />요일',
+	text_month: ' <b />월',
+	text_dom: ' <b />일',
+	error1: 'The tag %s is not supported !',
+	error2: 'Bad number of elements',
+	error3: 'The jquery_element should be set into jqCron settings',
+	error4: 'Unrecognized expression',
+	weekdays: ['월', '화', '수', '목', '금', '토', '일'],
+	months: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
+};


### PR DESCRIPTION
changelog:

1. add korean translation.
2. tiny indentation 2 spaces to tab charactor.
3. cron picker order according to lang ( now, only available 'ko' )

details:

korea is use 'YYYY-MM-DD HH:mm:ss' time format generally.

desc order is natural in korea, even if it is abstract. so, we are when display a time, it is natural in the context to display the month first rather than the day.

now, picker order is enabled only 'ko'
if you need more, change like next example code. jqCron.js:
```javascript
// jqCron.js#379 line.
if ( /^(ko)$/i.test(settings.lang) ) // if want add lang same ordering. just add in regexp.
{
	_$blocks.append(_$blockMONTH, _$blockDOM);
}
else if ( /^(some|other|lang)$/i.test(settings.lang) ) // if need more, add codes.
{
	// codes...
}
else // default ordering
{
	_$blocks.append(_$blockDOM, _$blockMONTH);
}
```