### PR TITLE
support minute labels

### DIFF
--- a/src/jqCron.js
+++ b/src/jqCron.js
@@ -16,6 +16,7 @@ var jqCronDefaultSettings = {
 	hours: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
 	hour_labels: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23"],
 	minutes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59],
+  minute_labels: ["00", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59"],
 	lang: 'en',
 	enabled_minute: false,
 	enabled_hour: true,
@@ -452,8 +453,8 @@ var jqCronDefaultSettings = {
 				_selectorTimeH.add(list[i], labelsList[i]);
 			}
 			_selectorTimeM = newSelector(_$blockTIME, settings.multiple_time_minutes, 'time_minutes');
-			for(i=0, list=settings.minutes; i<list.length; i++){
-				_selectorTimeM.add(list[i], list[i]);
+			for(i=0, list=settings.minutes, labelsList=settings.minute_labels; i<list.length; i++){
+        _selectorTimeM.add(list[i], labelsList[i]);
 			}
 
 			// DOW  (day of week)


### PR DESCRIPTION
Thank you for creating this library it has been useful for our purposes. We do have a need to support some additional customization for how minutes are displayed (specifically a request came in to make the minutes show up as double digits consistently to make it more consistent with how we typically see minutes on digital clocks and also to avoid confusion in cases where 4:5 can sometimes be visually interpreted as 4:50 when it actually means 4:05)

Cheers :beers: 
