### PR TITLE
weekdays should start at Sunday for Quartz (Sunday=1, Monday=2...)

### DIFF
--- a/src/jqCron.en.js
+++ b/src/jqCron.en.js
@@ -31,6 +31,6 @@ jqCronDefaultSettings.texts.en = {
 	error2: 'Bad number of elements',
 	error3: 'The jquery_element should be set into jqCron settings',
 	error4: 'Unrecognized expression',
-	weekdays: ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'],
+	weekdays: ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'],
 	months: ['january', 'february', 'march', 'april', 'may', 'june', 'july', 'august', 'september', 'october', 'november', 'december']
 };


### PR DESCRIPTION
Moved the "sunday" description to the first element of the array of "weekdays".